### PR TITLE
feat: set api base for railway backend

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,7 +1,10 @@
 const isDev = !!import.meta.env.DEV
 // En desarrollo, forzamos rutas relativas para usar el proxy de Vite.
 // En producción, permitimos configurar API_BASE vía VITE_API_BASE.
-const API_BASE = (!isDev ? (import.meta.env.VITE_API_BASE || '') : '').replace(/\/$/, '')
+const API_BASE = (!isDev
+  ? (import.meta.env.VITE_API_BASE || 'https://curvasdesembolsoserver-production.up.railway.app')
+  : ''
+).replace(/\/$/, '')
 
 async function request(path, options = {}) {
   const url = API_BASE ? `${API_BASE}${path}` : path


### PR DESCRIPTION
## Summary
- default API base to deployed Railway server when env not provided

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b06b34be0c83309418b9384e2cbc0d