### PR TITLE
Enable prediction bands popover

### DIFF
--- a/src/components/ProjectPopover.jsx
+++ b/src/components/ProjectPopover.jsx
@@ -7,14 +7,15 @@ import { getPredictionBands } from '../api/client'
 export default function ProjectPopover({ open, onClose, data }) {
   const ref = useRef(null)
   const tooltipRef = useRef(null)
-  const [showBands, setShowBands] = useState(false)
+  const [showBands, setShowBands] = useState(true)
   const [method, setMethod] = useState('bootstrap')
   const [level, setLevel] = useState('90')
 
   // Sync state with query params on mount
   useEffect(() => {
     const qs = new URLSearchParams(window.location.search)
-    setShowBands(qs.get('pb') === '1')
+    const pb = qs.get('pb')
+    setShowBands(pb === null ? true : pb === '1')
     setMethod(qs.get('pb_m') || 'bootstrap')
     setLevel(qs.get('pb_l') || '90')
   }, [])


### PR DESCRIPTION
## Summary
- remove variance band controls from curve workbench
- show project prediction bands in a popover that opens when clicking points
- enable prediction bands by default in the project popover with adjustable method and confidence level

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4d07ec09483309b382bf60406dc6f