### PR TITLE
feat: add cohort and project view toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ export default function App() {
   const [compareItems, setCompareItems] = useState([]) // up to 7 curves
   const [showActivePoints, setShowActivePoints] = useState(true)
   const [showPointCloud, setShowPointCloud] = useState(false)
+  const [viewMode, setViewMode] = useState('cohort') // 'cohort' or 'project'
 
   function addCurrentAsCompare(filtersArg) {
     if (compareItems.length >= 7) return
@@ -100,6 +101,18 @@ export default function App() {
     <div className="app">
       <header className="header">
         <h1>Curvas de Desembolso</h1>
+        <div style={{ marginTop:8 }}>
+          <button
+            className="chip"
+            onClick={() => setViewMode('cohort')}
+            style={{ marginRight:8, background: viewMode==='cohort' ? 'var(--line-main)' : undefined }}
+          >Cohorte (histórico)</button>
+          <button
+            className="chip"
+            onClick={() => setViewMode('project')}
+            style={{ background: viewMode==='project' ? 'var(--line-main)' : undefined }}
+          >Proyecto</button>
+        </div>
       </header>
       <div className="layout">
         <aside className="sidebar">
@@ -119,7 +132,13 @@ export default function App() {
           />
         </aside>
         <main className="content">
-          <CurveWorkbench filters={filters} compareItems={compareItems} showActivePoints={showActivePoints} showPointCloud={showPointCloud} />
+          <CurveWorkbench
+            filters={filters}
+            compareItems={compareItems}
+            showActivePoints={showActivePoints}
+            showPointCloud={showPointCloud}
+            viewMode={viewMode}
+          />
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add view mode toggle between cohort and project
- render cohort quantile bands with optional project overlay

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4d9cfd6e083309cd1364c3cf105b2