### PR TITLE
Avoid empty query strings and clean up imports

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -38,7 +38,10 @@ export function postCurveFit(filters, opts = {}) {
 
 export function getProjectTimeseries(iatiidentifier, params = {}) {
   const qs = new URLSearchParams(params)
-  return request(`/api/projects/${encodeURIComponent(iatiidentifier)}/timeseries?${qs}`)
+  const query = qs.toString()
+  const base = `/api/projects/${encodeURIComponent(iatiidentifier)}/timeseries`
+  const path = query ? `${base}?${query}` : base
+  return request(path)
 }
 
 export function getPredictionBands(projectId, params = {}) {

--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import useSWR from 'swr'
 import { getFilters } from '../api/client'
 


### PR DESCRIPTION
## Summary
- Ensure getProjectTimeseries only appends a query string when params are provided
- Remove unused `useMemo` import in FiltersPanel

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4f8f545f88330be8823928e8a8fe9