### PR TITLE
Use GET for prediction bands

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -56,9 +56,12 @@ export function getPredictionBands(params = {}, opts = {}) {
   } = params
   const qs = new URLSearchParams({ method, level, smooth })
   if (iatiidentifier) qs.set('iatiidentifier', iatiidentifier)
-  return request(`/api/curves/prediction-bands?${qs.toString()}`,{ 
-    method: 'POST',
-    body: JSON.stringify(filters),
+  for (const [k, v] of Object.entries(filters)) {
+    if (Array.isArray(v)) v.forEach(val => qs.append(k, val))
+    else if (v !== undefined && v !== null) qs.append(k, v)
+  }
+  return request(`/api/curves/prediction-bands?${qs.toString()}`, {
+    method: 'GET',
     ...opts,
   })
 }


### PR DESCRIPTION
## Summary
- Ensure prediction band requests use GET and avoid sending bodies or Content-Type headers
- Allow optional `iatiidentifier` and convert remaining filters to query params

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b514fb71408330a6c055bda4917ef5