### PR TITLE
Fix comparison filters mutation when adding curves

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,12 +32,26 @@ export default function App() {
     const computedLabel = mdb ? `${mdb} · ${base}` : base
     const yearsSuffix = `${f.yearFrom}\u2013${f.yearTo}`
     const defaultLabel = `${computedLabel} · ${yearsSuffix}`
+
+    // Deep-clone filters to freeze state at add time
+    const frozenFilters = {
+      macrosectors: [...(f.macrosectors || [])],
+      modalities: [...(f.modalities || [])],
+      countries: [...(f.countries || [])],
+      mdbs: [...(f.mdbs || [])],
+      ticketMin: f.ticketMin,
+      ticketMax: f.ticketMax,
+      yearFrom: f.yearFrom,
+      yearTo: f.yearTo,
+      onlyExited: f.onlyExited,
+    }
+
     const label = (filtersArg && filtersArg.label) ? filtersArg.label : defaultLabel
     const item = {
       id: Date.now().toString(),
       label,
       // Persist the filter state including the time interval at add time
-      filters: { ...f },
+      filters: frozenFilters,
     }
     setCompareItems(prev => [...prev, item])
   }


### PR DESCRIPTION
## Summary
- deep clone filters when adding comparisons to preserve original settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b524d068808330911e2aeea5126f60