### PR TITLE
Add 5-FP country group and improve prediction bands

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,9 @@ export default function App() {
   const [showActivePoints, setShowActivePoints] = useState(true)
   const [showPointCloud, setShowPointCloud] = useState(false)
 
+  const filtersEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b)
+  const hideMainCurve = compareItems.some(ci => filtersEqual(ci.filters, filters))
+
   function addCurrentAsCompare(filtersArg) {
     if (compareItems.length >= 7) return
     // Accept either raw filters or { filters, label }
@@ -141,6 +144,7 @@ export default function App() {
               compareItems={compareItems}
               showActivePoints={showActivePoints}
               showPointCloud={showPointCloud}
+              hideMainCurve={hideMainCurve}
             />
           </Suspense>
         </main>

--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react'
 import useSWR from 'swr'
 import { getFilters } from '../api/client'
 
+const FIVE_FP = ['AR', 'BO', 'BR', 'PY', 'UY']
+
 export default function FiltersPanel({ filters, onChange, onAddCompare, canAdd, onClearCompare, compareItems, onRemoveCompare, showActivePoints, onToggleActivePoints, showPointCloud, onTogglePointCloud, onCombine }) {
   const { data, error } = useSWR('/api/filters', getFilters, {
     revalidateOnFocus: false,
@@ -56,10 +58,11 @@ export default function FiltersPanel({ filters, onChange, onAddCompare, canAdd, 
     if (typeof onToggleActivePoints === 'function') onToggleActivePoints(true)
   }
 
+  const isFiveFP = FIVE_FP.every(c => local.countries.includes(c)) && local.countries.length === FIVE_FP.length
   const summary = [
     local.macrosectors.length===1 ? `Macrosector: ${data.macrosectors.find(m=>m.id===local.macrosectors[0])?.name}` : 'Macrosector: Global',
     local.modalities.length===1 ? `Modalidad: ${data.modalities.find(m=>m.id===local.modalities[0])?.name}` : 'Modalidad: Global',
-    local.countries.length===1 ? `País: ${local.countries[0]}` : 'País: Global',
+    isFiveFP ? 'País: 5-FP' : (local.countries.length===1 ? `País: ${local.countries[0]}` : 'País: Global'),
     (local.mdbs?.length===1 ? `MDB: ${data.mdbs.find(m=>m.id===local.mdbs[0])?.name || local.mdbs[0]}` : 'MDB: Global'),
   ]
 
@@ -94,14 +97,22 @@ export default function FiltersPanel({ filters, onChange, onAddCompare, canAdd, 
 
       <div className="field">
         <label className="hint">País</label>
-        <select className="select" value={local.countries[0] || ''} onChange={e => {
-          const v = e.target.value
-          setLocal(prev => ({ ...prev, countries: v ? [v] : [] }))
-        }}>
+        <select
+          className="select"
+          value={isFiveFP ? '5-FP' : (local.countries[0] || '')}
+          onChange={e => {
+            const v = e.target.value
+            setLocal(prev => ({
+              ...prev,
+              countries: v === '' ? [] : (v === '5-FP' ? [...FIVE_FP] : [v]),
+            }))
+          }}
+        >
           <option value="">Global (Todos)</option>
           {data.countries.map(c => (
             <option key={c} value={c}>{c}</option>
           ))}
+          <option value="5-FP">5-FP</option>
         </select>
       </div>
 


### PR DESCRIPTION
## Summary
- Add "5-FP" shortcut to select AR/BO/BR/PY/UY as a group in country filter.
- Hide main curve when it duplicates a comparison to avoid repeated lines.
- Make prediction band rendering adaptive to available quantiles so 90% intervals display.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5977e6e8c833085569313dd591d48