### PR TITLE
fix: improve comparison labels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,10 +26,21 @@ export default function App() {
     if (compareItems.length >= 7) return
     // Accept either raw filters or { filters, label }
     const f = (filtersArg && filtersArg.filters) ? filtersArg.filters : (filtersArg || filters)
-    const macro = f.macrosectors.length===1 ? (MACROSECTOR_LABELS[f.macrosectors[0]] || 'Global') : 'Global'
-    const modality = f.modalities.length===1 ? (MODALITY_LABELS[f.modalities[0]] || 'Todas') : 'Todas'
-    const country = f.countries.length===1 ? f.countries[0] : 'Global'
-    const mdb = (Array.isArray(f.mdbs) && f.mdbs.length===1) ? f.mdbs[0] : null
+    const macro = f.macrosectors.length === 1
+      ? (MACROSECTOR_LABELS[f.macrosectors[0]] ?? f.macrosectors[0])
+      : 'Global'
+    const modality = f.modalities.length === 1
+      ? (MODALITY_LABELS[f.modalities[0]] ?? f.modalities[0])
+      : 'Todas'
+    const country = (() => {
+      if (f.countries.length === 1) return f.countries[0]
+      if (f.countries.length > 1) {
+        const [first, ...rest] = f.countries
+        return `${first}+${rest.length}`
+      }
+      return 'Global'
+    })()
+    const mdb = (Array.isArray(f.mdbs) && f.mdbs.length === 1) ? f.mdbs[0] : null
     // Default compact label; allow override via filtersArg.label
     const base = `${country} · ${macro} · ${modality}`
     const computedLabel = mdb ? `${mdb} · ${base}` : base

--- a/src/labels.js
+++ b/src/labels.js
@@ -1,4 +1,11 @@
 export const MACROSECTOR_LABELS = {
+  1: 'Infraestructura',
+  2: 'Productivo',
+  3: 'Social',
+  4: 'Ambiental',
+  5: 'Gobernanza – Público',
+  6: 'Multisectorial – Otros',
+  // legacy ids
   11: 'Infraestructura',
   22: 'Productivo',
   33: 'Social',
@@ -8,6 +15,11 @@ export const MACROSECTOR_LABELS = {
 }
 
 export const MODALITY_LABELS = {
+  1: 'Investment',
+  2: 'Results',
+  3: 'Emergency',
+  4: 'Policy-Based',
+  // legacy ids
   111: 'Investment',
   222: 'Results',
   333: 'Emergency',


### PR DESCRIPTION
## Summary
- handle updated macrosector and modality IDs
- generate clearer labels for comparison curves

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b59b0c75808330b438c720b3c87336