### PR TITLE
feat: add toggle for disbursement origin

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ export default function App() {
     yearFrom: 2010,
     yearTo: 2024,
     onlyExited: true,
+    fromFirstDisbursement: false,
   })
   const [compareItems, setCompareItems] = useState([]) // up to 7 curves
   const [showActivePoints, setShowActivePoints] = useState(true)
@@ -58,6 +59,7 @@ export default function App() {
       yearFrom: f.yearFrom,
       yearTo: f.yearTo,
       onlyExited: f.onlyExited,
+      fromFirstDisbursement: f.fromFirstDisbursement,
     }
 
     const label = (filtersArg && filtersArg.label) ? filtersArg.label : defaultLabel
@@ -102,6 +104,7 @@ export default function App() {
       yearFrom,
       yearTo,
       onlyExited: true,
+      fromFirstDisbursement: picks.every(p => p.filters?.fromFirstDisbursement),
     }
     // Build compact combined label: "MDB · AR+BO+BR+2 · Macro · Modality"
     const mdbPart = (mdbsUnion.length === 1)

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -29,15 +29,19 @@ export function getFilters() {
 }
 
 export function postCurveFit(filters, opts = {}) {
+  const body = { ...filters }
+  if (!body.fromFirstDisbursement) delete body.fromFirstDisbursement
   return request('/api/curves/fit', {
     method: 'POST',
-    body: JSON.stringify(filters),
+    body: JSON.stringify(body),
     ...opts,
   })
 }
 
 export function getProjectTimeseries(iatiidentifier, params = {}) {
-  const qs = new URLSearchParams(params)
+  const { fromFirstDisbursement, ...rest } = params
+  const qs = new URLSearchParams(rest)
+  if (fromFirstDisbursement) qs.set('fromFirstDisbursement', 'true')
   const query = qs.toString()
   const base = `/api/projects/${encodeURIComponent(iatiidentifier)}/timeseries`
   const path = query ? `${base}?${query}` : base
@@ -52,10 +56,12 @@ export function getPredictionBands(params = {}, opts = {}) {
     method = 'historical_quantiles',  // método por defecto
     level = 80,
     smooth = true,
+    fromFirstDisbursement,
     ...filters
   } = params
   const qs = new URLSearchParams({ method, level, smooth })
   if (iatiidentifier) qs.set('iatiidentifier', iatiidentifier)
+  if (fromFirstDisbursement) qs.set('fromFirstDisbursement', 'true')
   for (const [k, v] of Object.entries(filters)) {
     if (Array.isArray(v)) v.forEach(val => qs.append(k, val))
     else if (v !== undefined && v !== null) qs.append(k, v)

--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -54,6 +54,7 @@ export default function FiltersPanel({ filters, onChange, onAddCompare, canAdd, 
       yearFrom: Math.max(2010, data.yearMin || 2010),
       yearTo: Math.min(2024, data.yearMax || 2024),
       onlyExited: true,
+      fromFirstDisbursement: false,
     })
     if (typeof onToggleActivePoints === 'function') onToggleActivePoints(true)
   }
@@ -155,10 +156,20 @@ export default function FiltersPanel({ filters, onChange, onAddCompare, canAdd, 
 
       <div className="field">
         <label className="hint">Años</label>
-        <div className="row">
-          <input className="input" type="number" min={data.yearMin} max={local.yearTo} value={local.yearFrom} onChange={e => setLocal(prev => ({ ...prev, yearFrom: Number(e.target.value) }))} />
-          <input className="input" type="number" min={local.yearFrom} max={data.yearMax} value={local.yearTo} onChange={e => setLocal(prev => ({ ...prev, yearTo: Number(e.target.value) }))} />
-        </div>
+      <div className="row">
+        <input className="input" type="number" min={data.yearMin} max={local.yearTo} value={local.yearFrom} onChange={e => setLocal(prev => ({ ...prev, yearFrom: Number(e.target.value) }))} />
+        <input className="input" type="number" min={local.yearFrom} max={data.yearMax} value={local.yearTo} onChange={e => setLocal(prev => ({ ...prev, yearTo: Number(e.target.value) }))} />
+      </div>
+    </div>
+
+      <div className="field">
+        <label className="hint">Origen de la curva</label>
+        <button
+          className={`btn ${local.fromFirstDisbursement ? 'btn--accent' : 'btn--ghost'}`}
+          onClick={() => setLocal(prev => ({ ...prev, fromFirstDisbursement: !prev.fromFirstDisbursement }))}
+        >
+          {local.fromFirstDisbursement ? 'Primer desembolso' : 'Aprobación'}
+        </button>
       </div>
 
       <div className="field row">


### PR DESCRIPTION
## Summary
- add frontend switch to send `fromFirstDisbursement` to backend
- propagate flag through curve, prediction band and timeseries requests

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5a6027dbc833093b49a96117f0729