### PR TITLE
Proxy API requests to avoid CORS errors

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,8 +1,10 @@
 const isDev = !!import.meta.env.DEV
 // En desarrollo, forzamos rutas relativas para usar el proxy de Vite.
-// En producción, permitimos configurar API_BASE vía VITE_API_BASE.
+// En producción, permitimos configurar API_BASE vía VITE_API_BASE, pero por
+// defecto usamos rutas relativas para que un proxy (por ejemplo, el nginx del
+// contenedor) reenvíe las peticiones y así evitar problemas de CORS.
 const API_BASE = (!isDev
-  ? (import.meta.env.VITE_API_BASE || 'https://curvasdesembolsoserver-production.up.railway.app')
+  ? (import.meta.env.VITE_API_BASE || '')
   : ''
 ).replace(/\/$/, '')
 


### PR DESCRIPTION
## Summary
- Use relative API base by default so a proxy can forward requests and avoid CORS failures.
- Proxy `/api` requests through nginx, stripping the Origin header and forwarding to the backend.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b69513e88330af1c1579c540348e