### PR TITLE
Move fromFirstDisbursement flag to query param

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -31,11 +31,14 @@ export function getFilters() {
 }
 
 export function postCurveFit(filters, opts = {}) {
-  const body = { ...filters }
-  if (!body.fromFirstDisbursement) delete body.fromFirstDisbursement
-  return request('/api/curves/fit', {
+  const { fromFirstDisbursement, ...rest } = filters
+  const qs = new URLSearchParams()
+  if (fromFirstDisbursement) qs.set('fromFirstDisbursement', 'true')
+  const query = qs.toString()
+  const path = query ? `/api/curves/fit?${query}` : '/api/curves/fit'
+  return request(path, {
     method: 'POST',
-    body: JSON.stringify(body),
+    body: JSON.stringify(rest),
     ...opts,
   })
 }


### PR DESCRIPTION
## Summary
- Send `fromFirstDisbursement` as query parameter in `postCurveFit`
- Include the flag in SWR key and display status codes in curve workbench errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2d0fadc8330afa1aa883512e888