### PR TITLE
Force relative API requests and handle network errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ WORKDIR /app
 COPY package*.json /app/
 RUN npm ci --no-audit --no-fund
 COPY . /app
-# Allow API base to be set at build time (Railway allows build envs)
-ARG VITE_API_BASE
-ENV VITE_API_BASE=${VITE_API_BASE}
 RUN npm run build
 
 # Serve static files with a lightweight server


### PR DESCRIPTION
## Summary
- avoid CORS failures by always using relative API routes
- catch network failures in API client
- simplify Dockerfile build stage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5c54d5dd88330bb8b49c23111d480