### PR TITLE
feat: add configurable prediction band controls

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -65,11 +65,12 @@ export function getPredictionBands(params = {}, opts = {}) {
     iatiidentifier,                   // opcional
     method = 'historical_quantiles',  // método por defecto
     level = 80,
+    minN = 30,
     smooth = true,
     fromFirstDisbursement,
     ...filters
   } = params
-  const qs = new URLSearchParams({ method, level, smooth })
+  const qs = new URLSearchParams({ method, level, smooth, minN })
   if (iatiidentifier) qs.set('iatiidentifier', iatiidentifier)
   if (fromFirstDisbursement) qs.set('fromFirstDisbursement', 'true')
   for (const [k, v] of Object.entries(filters)) {


### PR DESCRIPTION
## Summary
- support minN and smoothing in prediction band API calls
- add UI controls for band method, level, minN, and smoothing
- render p_low–p_high bands with coverage badge and detailed tooltips

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b99035a7a4833084c6667de33555b0