### PR TITLE
chore: remove prediction bands from frontend

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -57,32 +57,6 @@ export function getProjectTimeseries(iatiidentifier, params = {}) {
   const path = query ? `${base}?${query}` : base
   return request(path)
 }
-
-// Obtener bandas históricas por cuantiles del portafolio filtrado.
-// Nota: iatiidentifier es OPCIONAL (si se envía, el backend lo excluye del cálculo).
-export function getPredictionBands(params = {}, opts = {}) {
-  const {
-    iatiidentifier,                   // opcional
-    method = 'historical_quantiles',  // método por defecto
-    level = 80,
-    minN = 30,
-    smooth = true,
-    fromFirstDisbursement,
-    ...filters
-  } = params
-  const qs = new URLSearchParams({ method, level, smooth, minN })
-  if (iatiidentifier) qs.set('iatiidentifier', iatiidentifier)
-  if (fromFirstDisbursement) qs.set('fromFirstDisbursement', 'true')
-  for (const [k, v] of Object.entries(filters)) {
-    if (Array.isArray(v)) v.forEach(val => qs.append(k, val))
-    else if (v !== undefined && v !== null) qs.append(k, v)
-  }
-  return request(`/api/curves/prediction-bands?${qs.toString()}`, {
-    method: 'GET',
-    ...opts,
-  })
-}
-
 export function getHealth() { return request('/api/health') }
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,7 +12,6 @@
   --accent-2:#ffbf00;      /* Amber */
   --accent-3:#7c4dff;      /* Violet */
   --line-main:#12b5ff;     /* Main curve */
-  --band-fill:#00e5ff;     /* Prediction band fill (areas) */
   /* Residual classes */
   --above:#00d08a;         /* Green */
   --below:#ff5a5f;         /* Red */


### PR DESCRIPTION
## Summary
- remove prediction band API call and related UI
- drop unused CSS variable for prediction band fill

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb0aef69e883308edd24befd35dc6d