### PR TITLE
feat: add prediction bands with coverage controls

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -12,6 +12,7 @@
   --accent-2:#ffbf00;      /* Amber */
   --accent-3:#7c4dff;      /* Violet */
   --line-main:#12b5ff;     /* Main curve */
+  --band-fill: var(--line-main);
   /* Residual classes */
   --above:#00d08a;         /* Green */
   --below:#ff5a5f;         /* Red */


### PR DESCRIPTION
## Summary
- add toggle and coverage chips to show prediction bands
- compute and render quantile bands client-side with backend fallback
- include band-fill color variable

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb3d55a27c8330827c1ffccf91d6bb