### PR TITLE
Handle camelCase band quantile fields

### DIFF
--- a/src/components/normalizeBands.test.js
+++ b/src/components/normalizeBands.test.js
@@ -19,3 +19,13 @@ test('normalizeBands derives p_low/p_high from p10/p90', () => {
   assert.deepStrictEqual(result.p_high, [0.3, 0.4])
 })
 
+test('normalizeBands accepts camelCase pLow/pHigh fields', () => {
+  const raw = [
+    { k: 0, pLow: 0.1, pHigh: 0.3 },
+    { k: 1, pLow: 0.2, pHigh: 0.4 }
+  ]
+  const result = normalizeBands(raw)
+  assert.deepStrictEqual(result.p_low, [0.1, 0.2])
+  assert.deepStrictEqual(result.p_high, [0.3, 0.4])
+})
+

--- a/src/lib/normalizeBands.js
+++ b/src/lib/normalizeBands.js
@@ -35,8 +35,8 @@ export function normalizeBands(raw = []) {
       p50:   toNum(pick(b, ["p50", "p_50", "median", "hd"])),
       p90:   toNum(pick(b, ["p90", "p_90"])),
       p97_5: toNum(pick(b, ["p97_5", "p_97_5", "p975"])),
-      p_low:  toNum(pick(b, ["p_low", "lower", "p10", "p_10", "p2_5", "p_2_5"])),
-      p_high: toNum(pick(b, ["p_high", "upper", "p90", "p_90", "p97_5", "p_97_5"])),
+      p_low:  toNum(pick(b, ["p_low", "pLow", "lower", "p10", "p_10", "p2_5", "p_2_5"])),
+      p_high: toNum(pick(b, ["p_high", "pHigh", "upper", "p90", "p_90", "p97_5", "p_97_5"])),
       n:      toNum(pick(b, ["n", "n_k", "count"])),
       low_sample_p80: toNum(pick(b, ["low_sample_p80"])),
       low_sample_p95: toNum(pick(b, ["low_sample_p95"]))


### PR DESCRIPTION
## Summary
- broaden normalizeBands to accept camelCase pLow/pHigh keys
- test camelCase quantile handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb5aca07948330a2c2bbd6566d043c