### PR TITLE
Send band coverage in body and guard optional bands

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -36,14 +36,22 @@ export function getFilters() {
 }
 
 export function postCurveFit(filters, opts = {}) {
-  const { fromFirstDisbursement, ...rest } = filters
+  const { fromFirstDisbursement, bandCoverage, ...rest } = filters
+
+  // Only fromFirstDisbursement is encoded in the query string. The band
+  // coverage must travel in the JSON body so the backend can decide whether to
+  // compute prediction bands.
   const qs = new URLSearchParams()
   if (fromFirstDisbursement) qs.set('fromFirstDisbursement', 'true')
   const query = qs.toString()
   const path = query ? `/api/curves/fit?${query}` : '/api/curves/fit'
+
+  const payload = { ...rest }
+  if (bandCoverage !== undefined) payload.bandCoverage = bandCoverage
+
   return request(path, {
     method: 'POST',
-    body: JSON.stringify(rest),
+    body: JSON.stringify(payload),
     ...opts,
   })
 }

--- a/src/components/CurveWorkbench.jsx
+++ b/src/components/CurveWorkbench.jsx
@@ -196,16 +196,18 @@ export default function CurveWorkbench({ filters, compareItems = [], showActiveP
     // Prediction bands
     const bandSources = []
     if (!hideMainCurve) {
-      if (showBands && !(data?.bandsQuantile || Array.isArray(data?.points))) {
-        console.warn('Band data requested but missing from main curve response')
-      }
-      bandSources.push({ params: data?.params, bandsQuantile: data?.bandsQuantile, points: data?.points, kDomain: data?.kDomain })
+      const src = { params: data?.params, kDomain: data?.kDomain }
+      if (data?.bandsQuantile) src.bandsQuantile = data.bandsQuantile
+      else if (Array.isArray(data?.points)) src.points = data.points
+      else if (showBands) console.warn('Band data requested but missing from main curve response')
+      bandSources.push(src)
     } else {
       compareList.forEach(cd => {
-        if (showBands && !(cd?.bandsQuantile || Array.isArray(cd?.points))) {
-          console.warn('Band data requested but missing from comparison response')
-        }
-        bandSources.push(cd)
+        const src = { params: cd?.params, kDomain: cd?.kDomain }
+        if (cd?.bandsQuantile) src.bandsQuantile = cd.bandsQuantile
+        else if (Array.isArray(cd?.points)) src.points = cd.points
+        else if (showBands) console.warn('Band data requested but missing from comparison response')
+        bandSources.push(src)
       })
     }
 
@@ -264,6 +266,8 @@ export default function CurveWorkbench({ filters, compareItems = [], showActiveP
             const dn = clamp01(hd + ql)
             if (Number.isFinite(up) && Number.isFinite(dn)) band.push({ k, hd_up: up, hd_dn: dn })
           }
+        } else {
+          console.warn('Band data requested but missing from curve source')
         }
         if (band.length) {
           const area = d3.area()


### PR DESCRIPTION
## Summary
- Ensure band coverage parameter is sent in POST body rather than query string when fitting curves
- Guard rendering of prediction bands by checking for `bandsQuantile` or raw points before drawing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb63c239d483308e58d5c5ef1d343d